### PR TITLE
Default Server Selection for Ollama Component

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   mode: "development",
   entry: "./src/index",
   output: {
-    //path: path.resolve(__dirname, '../../backend/plugins/shared/BrainDriveSettings/v1.0.2/dist'),
+    //path: path.resolve(__dirname, '../../backend/plugins/shared/BrainDriveSettings/v1.0.4/dist'),
     path: path.resolve(__dirname, 'dist'),
     publicPath: "auto",
     clean: true,


### PR DESCRIPTION
## 🚀 Pull Request: Default Server Selection for Ollama Component

### Summary

This PR improves the **Ollama Server component** by ensuring a default server is automatically selected when servers are loaded. It also introduces a refactor for more consistent state handling, and bumps the plugin output path version in `webpack.config.js`.

### Changes

#### `src/ComponentOllamaServer.tsx`

* **Added**:

  * `applyLoadedServers()` helper method:

    * Selects an existing active server if still valid.
    * Falls back to the first available server if no active one is set.
    * Ensures models are reloaded when switching active servers while on the “models” tab.
    * Handles empty server lists gracefully.

* **Updated**:

  * Replaced multiple direct `setState` calls in `loadSettings` and refresh flows with calls to `applyLoadedServers`.
  * Simplified state management logic by centralizing it in one method.

#### `webpack.config.js`

* Updated plugin dist path comment reference from `v1.0.2` → `v1.0.5`.

### Why This Change?

* Users previously needed to manually select a server after loading; this PR ensures a **default active server** is always set, streamlining UX.
* Consolidating logic into `applyLoadedServers` reduces duplication and makes the codebase more maintainable.
* Version bump aligns with updated plugin distribution.

### Testing & Verification

* Confirmed that on initial load, the first available server becomes active if none was previously set.
* Verified models reload automatically when active server changes on the “models” tab.
* Tested behavior when no servers exist — no crash, state handled cleanly.
* Confirmed build still works with updated webpack config.

### Next Steps / Future Considerations

* Add unit tests around `applyLoadedServers` to validate behavior under different server states.
* Consider exposing default server selection in UI settings for advanced users.
* Document server auto-selection behavior in user guide.

